### PR TITLE
修复角色及用户权限树勾选Bug

### DIFF
--- a/angular/src/app/admin/shared/permission-tree/permission-tree.component.html
+++ b/angular/src/app/admin/shared/permission-tree/permission-tree.component.html
@@ -8,5 +8,5 @@
     </ng-template>
 
     <nz-tree #nzTreePermission [nzData]="_treeData" [nzSearchValue]="filterText" [nzCheckable]="true" [nzShowLine]="false"
-        [nzExpandAll]="true" [nzCheckedKeys]="defaultCheckedPermissionNames" [nzCheckStrictly]="checkStrictly" class="mt-md"></nz-tree>
+        [nzExpandAll]="true" [nzCheckStrictly]="checkStrictly" class="mt-md"></nz-tree>
 </nz-spin>

--- a/angular/src/app/admin/shared/permission-tree/permission-tree.component.ts
+++ b/angular/src/app/admin/shared/permission-tree/permission-tree.component.ts
@@ -11,15 +11,12 @@ import { PermissionTreeEditModel } from '@app/admin/shared/permission-tree/permi
 export class PermissionTreeComponent extends AppComponentBase implements OnInit {
     private _editData: PermissionTreeEditModel;
 
-    defaultCheckedPermissionNames: string[] = [];
-
     checkStrictly = true;
 
     loading = false;
 
     set editData(val: PermissionTreeEditModel) {
         this._editData = val;
-        this.defaultCheckedPermissionNames = val.grantedPermissionNames;
         this.arrToTreeNode();
     }
 
@@ -42,7 +39,10 @@ export class PermissionTreeComponent extends AppComponentBase implements OnInit 
                 idMapName: 'name',
                 parentIdMapName: 'parentName',
                 titleMapName: 'displayName',
-                cb: (item) => { item.expanded = true }
+                cb: (item) => { 
+                    item.expanded = true;
+                    item.checked = item.isLeaf == true && this._editData.grantedPermissionNames.indexOf(item.name) != -1 ? true : false;
+                }
             },
         );
 


### PR DESCRIPTION
感谢作者为abp zero前端开源的贡献，abp zero配套及未完善的功能后续持续优化，本次提交内容如下：

- 修复nz-tree组件父子节点选中状态会与子节点关联，导致用户或角色权限选择页面同一组checkbox全部被选中的问题
